### PR TITLE
[#24] 뱃지 컴포넌트 구현

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -4,6 +4,13 @@ import '../src/index.css';
 
 const preview: Preview = {
   parameters: {
+    backgrounds: {
+      default: 'figma-light',
+      values: [
+        { name: 'figma-light', value: '#C3C2C2' },
+        { name: 'figma-dark', value: '#333333' },
+      ],
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/src/components/common/Badge/Badge.stories.tsx
+++ b/src/components/common/Badge/Badge.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Badge from '@/components/common/Badge';
+
+const meta: Meta = {
+  title: '뱃지',
+  component: Badge,
+};
+
+export default meta;
+
+export type Story = StoryObj<typeof Badge>;
+
+export const ForDisplay: Story = {
+  args: {
+    text: '거실',
+  },
+};
+
+export const ForButton: Story = {
+  args: {
+    text: '뱃지',
+    type: 'button',
+  },
+};

--- a/src/components/common/Badge/index.tsx
+++ b/src/components/common/Badge/index.tsx
@@ -1,9 +1,9 @@
 import { Badge, BadgeProps } from '@/components/ui/badge';
-import { ReactNode } from 'react';
+import { HTMLAttributes, ReactNode } from 'react';
 import { FiPlus } from 'react-icons/fi';
 import { cn } from '@/utils.ts';
 
-interface BadeWrapperProps {
+interface BadeWrapperProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'type'> {
   text: string;
   type?: 'button' | 'display';
   size?: 'medium' | 'small';

--- a/src/components/common/Badge/index.tsx
+++ b/src/components/common/Badge/index.tsx
@@ -1,0 +1,60 @@
+import { Badge, BadgeProps } from '@/components/ui/badge';
+import { ReactNode } from 'react';
+import { FiPlus } from 'react-icons/fi';
+import { cn } from '@/utils.ts';
+
+interface BadeWrapperProps {
+  text: string;
+  type?: 'button' | 'display';
+  size?: 'medium' | 'small';
+}
+
+const BadgeWrapper = ({
+  text,
+  type = 'display',
+  size = 'medium',
+  ...buttonProps
+}: BadeWrapperProps) => {
+  if (type === 'button') {
+    return (
+      <button {...buttonProps}>
+        <BadgeContent
+          text={text}
+          icon={<FiPlus size={14} />}
+          size={size}
+          className={'bg-gray-50 text-gray-800'}
+        />
+      </button>
+    );
+  }
+
+  return (
+    <button {...buttonProps}>
+      <BadgeContent text={text} size={size} className={'bg-gray-500 text-white'} />
+    </button>
+  );
+};
+
+interface BadgeContentProps extends BadgeProps {
+  text: string;
+  icon?: ReactNode;
+  size: 'medium' | 'small';
+}
+
+const BadgeContent = ({ text, icon, className, size, ...rest }: BadgeContentProps) => {
+  return (
+    <Badge
+      className={cn(
+        'flex w-fit flex-row items-center gap-1 px-2',
+        size === 'medium' ? 'py-1' : 'py-0.5',
+        className,
+      )}
+      {...rest}
+    >
+      {icon}
+      <span className={cn(size === 'medium' ? 'text-small-writing' : 'text-sub-typo')}>{text}</span>
+    </Badge>
+  );
+};
+
+export default BadgeWrapper;

--- a/src/components/common/Badge/index.tsx
+++ b/src/components/common/Badge/index.tsx
@@ -52,7 +52,11 @@ const BadgeContent = ({ text, icon, className, size, ...rest }: BadgeContentProp
       {...rest}
     >
       {icon}
-      <span className={cn(size === 'medium' ? 'text-small-writing' : 'text-sub-typo')}>{text}</span>
+      <span
+        className={cn('font-medium', size === 'medium' ? 'text-small-writing' : 'text-sub-typo')}
+      >
+        {text}
+      </span>
     </Badge>
   );
 };

--- a/src/components/common/Card/Card.stories.tsx
+++ b/src/components/common/Card/Card.stories.tsx
@@ -12,12 +12,10 @@ export type Story = StoryObj<typeof Card>;
 
 export const Default: Story = {
   render: () => (
-    <div className={'w-full h-96 bg-gray-300 p-6'}>
-      <Card.Container verticalPaddingSize={'large'}>
-        <Card.Content className={'p-0 text-regular-body font-semibold text-center'}>
-          텍스트를 입력하세요
-        </Card.Content>
-      </Card.Container>
-    </div>
+    <Card.Container verticalPaddingSize={'large'}>
+      <Card.Content className={'p-0 text-regular-body font-semibold text-center'}>
+        텍스트를 입력하세요
+      </Card.Content>
+    </Card.Container>
   ),
 };

--- a/src/components/common/List/index.tsx
+++ b/src/components/common/List/index.tsx
@@ -1,4 +1,5 @@
 import { IoIosArrowForward } from 'react-icons/io';
+import Badge from '@/components/common/Badge';
 
 interface IndexProps {
   image?: string;
@@ -26,12 +27,7 @@ const index: React.FC<IndexProps> = ({ image, name, badges, onChange }) => {
             <div className="flex gap-[5px]">
               {badges &&
                 badges.map((badge, index) => (
-                  <div
-                    key={index}
-                    className="w-[47px] h-[23px] rounded-[13px] bg-slate-500 text-white text-small-writing flex items-center justify-center px-[8px] py-[3px]"
-                  >
-                    {badge}
-                  </div>
+                  <Badge text={badge} key={`${badge}-${index}`} size={'small'} type={'display'} />
                 ))}
             </div>
           </div>

--- a/src/components/common/TextFieldV2/index.tsx
+++ b/src/components/common/TextFieldV2/index.tsx
@@ -29,7 +29,7 @@ const TextFieldV2 = ({
       </Label>
       <div
         className={cn(
-          'w-full px-2.5 pt-0 pb-3 flex flex-row justify-between items-center border-b-2 border-gray-100',
+          'w-full px-2.5 pt-0 pb-3 flex flex-row justify-between items-center border-b-2 border-gray-100 bg-white',
           inputClassName,
         )}
       >

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## What is this PR? :mag:
뱃지 컴포넌트 구현했습니다! 추가적으로 storybook 배경색 피그마랑 통일 시켰습니다!

## Changes :memo:
아래처럼 사용할 수 있습니다!
```tsx
<Badge type="button" text="뱃지" size="meidum" onClick={}  />
```

인터페이스 정보 입니다!

```tsx
interface BadeWrapperProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'type'> {
  text: string;
  type?: 'button' | 'display';
  size?: 'medium' | 'small';
}
```

보시는 것처럼 text, type, size 라는 프로퍼티를 받고 이외에 버튼 태그에 사용되는 애트리뷰트를 받을 수 있게 했습니다!

추가적으로 리스트 스토리북에 뱃지도 교체했습니다!

## Screenshot :camera:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/e003a192-d8c1-438e-8328-47c8cbb107e5">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/73a8e271-7d43-4ebf-aec8-db09e93b1d6b">
