### PR TITLE
[# 198] 센터 바텀 시트 컴포넌트 UI 수정

### DIFF
--- a/src/components/common/CenterBottomSheet/index.tsx
+++ b/src/components/common/CenterBottomSheet/index.tsx
@@ -29,7 +29,7 @@ const CenterBottomSheet = ({
         </div>
         <header
           className={cn(
-            'text-start px-2.5 text-Gray800',
+            'text-start px-2.5 text-Gray800 whitespace-pre-wrap',
             headerAsLabel
               ? 'text-small-writing font-medium'
               : 'text-small-title font-bold leading-[29px]',

--- a/src/components/common/CenterBottomSheet/index.tsx
+++ b/src/components/common/CenterBottomSheet/index.tsx
@@ -24,7 +24,7 @@ const CenterBottomSheet = ({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className={'rounded-3xl'}>
-        <div className="flex justify-center">
+        <div className="flex justify-center my-2.5">
           <div className="w-12 h-1 bg-Gray100 rounded-full" />
         </div>
         <header

--- a/src/components/common/CenterBottomSheet/index.tsx
+++ b/src/components/common/CenterBottomSheet/index.tsx
@@ -39,7 +39,10 @@ const CenterBottomSheet = ({
         </header>
         <DialogDescription>{content}</DialogDescription>
         <DialogFooter
-          className={cn('flex mt-[30px]', actionDirection === 'row' ? 'flex-row' : 'flex-col')}
+          className={cn(
+            'flex mt-[30px] gap-3',
+            actionDirection === 'row' ? 'flex-row' : 'flex-col',
+          )}
         >
           {...actions}
         </DialogFooter>


### PR DESCRIPTION
## What is this PR? :mag:
센터 파텀 시트 컴포넌트 UI 수정

## Changes :memo:
- 헤더 위 세퍼레이터에 y 마진 10px 추가
- 헤더에 white-space-pre-wrap 추가
- 푸터 actions에 gap 12px 추가

## Screenshot :camera:
