### PR TITLE
[# 204] 식물 추가 페이지 상단 x 버튼 클릭시 뒤로가기가 아닌 메인페이지로 가도록 수정

### DIFF
--- a/src/pages/AddPlantPage.tsx
+++ b/src/pages/AddPlantPage.tsx
@@ -147,7 +147,7 @@ const AddPlantPage = () => {
         right={
           <button
             onClick={() => {
-              router.goBack();
+              router.replace('/');
             }}
           >
             <IconXMono />


### PR DESCRIPTION
## What is this PR? :mag:
식물 추가 페이지 상단 x 버튼 클릭시 뒤로가기가 아닌 메인페이지로 가도록 수정했습니다.

## Changes :memo:
- AddPlantPage 컴포넌트의 Header 버튼이 goBack이 아닌 replace('/")를 실행하도록 변경

## Screenshot :camera:
