### PR TITLE
fix: 식물 등록시 닉네임 필드 값이 비어져서 요청이 보내지던 문제 수정

### DIFF
--- a/src/pages/AddPlantPage.tsx
+++ b/src/pages/AddPlantPage.tsx
@@ -198,6 +198,7 @@ const AddPlantPage = () => {
           title={'반려식물 애칭'}
           placeholder={addPlantForm.scientificName.value}
           essential={false}
+          onChange={(e) => handleChange('nickname', e.target.value)}
         />
 
         <NotificationToggleList


### PR DESCRIPTION
## What is this PR? :mag:
식물 등록시 닉네임 필드 값이 비어져서 요청이 보내지던 문제 수정했습니다.

## Changes :memo:
- 닉네임 입력 텍스트 필드에 이벤트 핸들러 등록되어있지 않던 문제 수정

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/8cce16e7-47c4-4d23-af1d-174d3d06f1e6)
